### PR TITLE
[chore] Axios 설정 및 테스트 API 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.61.0",
     "@tanstack/react-query-devtools": "^5.61.0",
+    "axios": "^1.7.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "jotai": "^2.10.2",

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,0 +1,56 @@
+import axios, {
+  AxiosError,
+  AxiosInstance,
+  CreateAxiosDefaults,
+  isAxiosError,
+} from 'axios';
+
+const BASE_URL = 'https://jsonplaceholder.typicode.com'; // 수정 필요
+
+const setInterceptor = (instance: AxiosInstance) => {
+  instance.interceptors.request.use(
+    (config) => {
+      const requestConfig = config;
+
+      // header에 sessionStorage에 저장되어 있는 token을 포함한다고 가정
+      // const accessToken = sessionStorage.getItem('token');
+
+      // if (accessToken) {
+      //   requestConfig.headers.Authorization = `Bearer ${accessToken}`;
+      // }
+      return config;
+    },
+    (err: AxiosError): Promise<AxiosError> => Promise.reject(err),
+  );
+
+  instance.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+      if (isAxiosError(error)) {
+        if (error.response && error.response.data) {
+          const { status, code, message } = error.response.data;
+          console.log(status, code, message);
+
+          return Promise.reject(error);
+        }
+      }
+
+      console.error(error);
+      return Promise.reject(error);
+    },
+  );
+
+  return instance;
+};
+
+const options: CreateAxiosDefaults = {
+  headers: {
+    Accept: '*/*',
+    'Content-type': 'application/json; charset=UTF-8',
+  },
+  baseURL: BASE_URL,
+};
+
+export const ax = axios.create(options);
+
+setInterceptor(ax);

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -4,6 +4,7 @@ import axios, {
   CreateAxiosDefaults,
   isAxiosError,
 } from 'axios';
+import { HttpStatusCode } from '@/constants/apiStatus';
 
 const BASE_URL = 'https://jsonplaceholder.typicode.com'; // 수정 필요
 
@@ -30,6 +31,14 @@ const setInterceptor = (instance: AxiosInstance) => {
         if (error.response && error.response.data) {
           const { status, code, message } = error.response.data;
           console.log(status, code, message);
+
+          if (status === HttpStatusCode.UNAUTHORIZED) {
+            // 다시 로그인
+          }
+
+          if (status === HttpStatusCode.INTERNAL_SERVER_ERROR) {
+            // 에러
+          }
 
           return Promise.reject(error);
         }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,2 @@
+export * from './axios';
+export { default as test } from './test';

--- a/src/api/test.ts
+++ b/src/api/test.ts
@@ -1,0 +1,28 @@
+import { ax } from './axios';
+
+interface PostRequest {
+  title: string;
+  body: string;
+  userID: number;
+}
+
+interface PostResponse {
+  id: number;
+  title: string;
+  body: string;
+  userID: number;
+}
+
+const test = {
+  postAPI: async (request: PostRequest): Promise<PostResponse> => {
+    try {
+      const res = await ax.post<PostResponse>('/posts', request);
+      return res.data;
+    } catch (error) {
+      console.error('API Error:', error);
+      throw error;
+    }
+  },
+};
+
+export default test;

--- a/src/api/test.ts
+++ b/src/api/test.ts
@@ -16,8 +16,8 @@ interface PostResponse {
 const test = {
   postAPI: async (request: PostRequest): Promise<PostResponse> => {
     try {
-      const res = await ax.post<PostResponse>('/posts', request);
-      return res.data;
+      const { data } = await ax.post<PostResponse>('/posts', request);
+      return data;
     } catch (error) {
       console.error('API Error:', error);
       throw error;

--- a/src/constants/apiStatus.ts
+++ b/src/constants/apiStatus.ts
@@ -1,0 +1,6 @@
+export enum HttpStatusCode {
+  SUCCESS = 200,
+  BAD_REQUEST = 400,
+  UNAUTHORIZED = 401,
+  INTERNAL_SERVER_ERROR = 500,
+}


### PR DESCRIPTION
## Motivation 🤔
1. `Axios.ts` : Axios 인스턴스 생성 및 요청/응답 인터셉터 설정
    - baseURL 수정 필요 : 현재는 테스트용으로 임시 삽입
    - 요청/응답 인터셉터 내부에 추가 로직 구현 필요
2.  `test.ts`: 테스트용 Post API 타입 및 메서드 예제 추가
    - API 작성 가이드 통일을 위해 삽입한 임시 파일로 추후 삭제 필요
    - 목적이 같은 API 메서드를 한 파일에 묶어 구성 ( user 안에 login, signup, userInfo API 구현 )
    - 메서드 이름과 동일하게 요청/응답 타입을 정의
3. `index.ts`: Axios와 API 모듈의 통합 관리 export 설정
    - 모듈을 통합적으로 관리할 수 있도록 구조화
 
## Key Changes 🔑
- 테스트용 API 메서드 구현 방식에 대해서 더 좋은 방법 있으면 알려쥬세여 🙈
- 추가되면 좋을 것 같은 부분이 있다면 알려주세용 ! 👀