### PR TITLE
[feat] 메모 기능 추가 구현 및 context api 구조 적용

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,8 @@
-import { Metadata } from 'next';
-import './globals.css';
+import { MemoProvider } from '@/contexts/memo/MemoProvider';
 import BaseQueryClientProvider from '@/contexts/tanstackQuery/BaseQueryClientProvider';
+import { Metadata } from 'next';
 import { pretendard } from './font';
+import './globals.css';
 
 // PWA 관련 세팅
 export const metadata: Metadata = {
@@ -16,12 +17,14 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang='en'>
       <body className={`layout ${pretendard.variable}`}>
         <BaseQueryClientProvider>
-          <div className="w-full h-[100dvh] bg-gray-100 font-pretendard">
-            {children}
-          </div>
+          <MemoProvider>
+            <div className='h-[100dvh] w-full bg-gray-100 font-pretendard'>
+              {children}
+            </div>
+          </MemoProvider>
         </BaseQueryClientProvider>
       </body>
     </html>

--- a/src/components/atoms/memo/Memo.tsx
+++ b/src/components/atoms/memo/Memo.tsx
@@ -4,6 +4,7 @@ import { cva } from 'class-variance-authority';
 import { forwardRef, useState } from 'react';
 import MemoDiv from './MemoDiv';
 import MemoTextarea from './MemoTextarea';
+import SubmitButton from './SubmitButton';
 
 export const memoVariants = cva(
   'inline-flex items-center box-border text-center py-2 px-3 rounded-md leading-tight font-medium break-words border-[1px] border-white/20 bg-white/20 focus:outline-none focus:ring-0',
@@ -57,14 +58,17 @@ export const Memo = forwardRef<HTMLDivElement, MemoProps>(
     });
 
     return isEditMode ? (
-      <MemoTextarea
-        ref={ref as React.Ref<HTMLTextAreaElement>}
-        text={memoText}
-        size={size}
-        setMemoText={setMemoText}
-        className={commonClass}
-        {...props}
-      />
+      <div className='flex h-full w-full flex-col items-center'>
+        <MemoTextarea
+          ref={ref as React.Ref<HTMLTextAreaElement>}
+          text={memoText}
+          size={size}
+          setMemoText={setMemoText}
+          className={commonClass}
+          {...props}
+        />
+        <SubmitButton text={memoText} setMemoText={setMemoText} />
+      </div>
     ) : (
       <MemoDiv
         ref={ref as React.Ref<HTMLDivElement>}

--- a/src/components/atoms/memo/Memo.tsx
+++ b/src/components/atoms/memo/Memo.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import useMemoContext from '@/contexts/memo/MemoContext';
 import { cva } from 'class-variance-authority';
-import { forwardRef, useState } from 'react';
+import { forwardRef } from 'react';
 import MemoDiv from './MemoDiv';
 import MemoTextarea from './MemoTextarea';
 import SubmitButton from './SubmitButton';
@@ -50,7 +51,7 @@ interface MemoProps {
 
 export const Memo = forwardRef<HTMLDivElement, MemoProps>(
   ({ isEditMode = false, text = '', size = 'medium', ...props }, ref) => {
-    const [memoText, setMemoText] = useState(text);
+    const { memoText } = useMemoContext();
 
     const commonClass = memoVariants({
       variant: memoText.trim() ? 'main' : 'none',
@@ -63,11 +64,10 @@ export const Memo = forwardRef<HTMLDivElement, MemoProps>(
           ref={ref as React.Ref<HTMLTextAreaElement>}
           text={memoText}
           size={size}
-          setMemoText={setMemoText}
           className={commonClass}
           {...props}
         />
-        <SubmitButton text={memoText} setMemoText={setMemoText} />
+        <SubmitButton />
       </div>
     ) : (
       <MemoDiv

--- a/src/components/atoms/memo/Memo.tsx
+++ b/src/components/atoms/memo/Memo.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import useMemoContext from '@/contexts/memo/MemoContext';
+import { MemoSize } from '@/types/memo/memoTypes';
 import { cva } from 'class-variance-authority';
 import { forwardRef } from 'react';
 import MemoDiv from './MemoDiv';
@@ -28,20 +29,6 @@ export const memoVariants = cva(
     },
   },
 );
-
-type SizeConfigItem = {
-  minWidth: number;
-  maxWidth: number;
-  minHeight: number;
-  maxHeight: number;
-};
-
-export type MemoSize = 'small' | 'medium';
-
-export const SIZE_CONFIG: Record<MemoSize, SizeConfigItem> = {
-  small: { minWidth: 58, maxWidth: 155, minHeight: 34, maxHeight: 52 },
-  medium: { minWidth: 63, maxWidth: 173, minHeight: 37, maxHeight: 58 },
-};
 
 interface MemoProps {
   isEditMode?: boolean;

--- a/src/components/atoms/memo/MemoDiv.tsx
+++ b/src/components/atoms/memo/MemoDiv.tsx
@@ -1,5 +1,5 @@
+import { MemoSize } from '@/types/memo/memoTypes';
 import { forwardRef } from 'react';
-import { MemoSize } from './Memo';
 
 interface MemoDivProps {
   text: string;

--- a/src/components/atoms/memo/MemoTextarea.tsx
+++ b/src/components/atoms/memo/MemoTextarea.tsx
@@ -1,4 +1,6 @@
 import useMemoContext from '@/contexts/memo/MemoContext';
+import { Dimensions, MemoSize, SIZE_CONFIG } from '@/types/memo/memoTypes';
+import { updateDimensions } from '@/utils/memo/memoUtils';
 import {
   ChangeEvent,
   forwardRef,
@@ -6,96 +8,6 @@ import {
   useRef,
   useState,
 } from 'react';
-import { MemoSize, SIZE_CONFIG } from './Memo';
-
-const TEXTAREA_PADDING = 24;
-
-// 메모 크기별 최대 텍스트 높이 설정
-const MAX_TEXT_HEIGHT: Record<MemoSize, number> = {
-  small: 51,
-  medium: 56,
-};
-const HEIGHT_PADDING: Record<MemoSize, number> = {
-  small: 2,
-  medium: 1,
-};
-
-// 텍스트의 크기를 계산하기 위한 임시 span 요소 생성 함수
-const createTempSpan = (
-  context: HTMLTextAreaElement,
-  newValue: string,
-): HTMLSpanElement => {
-  const tempSpan = document.createElement('span');
-  tempSpan.style.visibility = 'hidden';
-  tempSpan.style.position = 'absolute';
-  tempSpan.style.whiteSpace = 'pre';
-  tempSpan.style.font = window.getComputedStyle(context).font;
-  tempSpan.textContent = newValue || ' ';
-  document.body.appendChild(tempSpan);
-  return tempSpan;
-};
-
-const calculateNewHeight = (
-  calculatedWidth: number,
-  textHeight: number,
-  maxTextHeight: number,
-  size: MemoSize,
-): number => {
-  const { maxWidth, minHeight, maxHeight } = SIZE_CONFIG[size];
-
-  // 최대 너비를 초과하면 최대 높이 반환
-  if (calculatedWidth >= maxWidth) {
-    return maxHeight;
-  }
-  // 최대 높이를 초과하면 최대 높이를 제한
-  if (textHeight >= maxTextHeight) {
-    return Math.min(textHeight + HEIGHT_PADDING[size], maxHeight);
-  }
-  return minHeight;
-};
-
-type Dimensions = {
-  width: number;
-  height: number;
-};
-
-type UpdateDimensions = {
-  width: number;
-  height: number;
-  textHeight: number;
-  maxTextHeight: number;
-};
-
-const updateDimensions = (
-  context: HTMLTextAreaElement,
-  text: string,
-  size: MemoSize,
-): UpdateDimensions => {
-  const { minWidth, maxWidth } = SIZE_CONFIG[size];
-
-  const tempSpan = createTempSpan(context, text);
-  const calculatedWidth = Math.min(
-    tempSpan.offsetWidth + TEXTAREA_PADDING,
-    maxWidth,
-  );
-  document.body.removeChild(tempSpan);
-
-  const textHeight = context.scrollHeight || 0;
-  const maxTextHeight = MAX_TEXT_HEIGHT[size];
-  const newHeight = calculateNewHeight(
-    calculatedWidth,
-    textHeight,
-    maxTextHeight,
-    size,
-  );
-
-  return {
-    width: Math.max(calculatedWidth, minWidth),
-    height: newHeight,
-    textHeight,
-    maxTextHeight,
-  };
-};
 
 // 글자수 초과 시 렌더되는 alert 컴포넌트
 const TextLimitAlert = (): JSX.Element => {

--- a/src/components/atoms/memo/MemoTextarea.tsx
+++ b/src/components/atoms/memo/MemoTextarea.tsx
@@ -1,4 +1,11 @@
-import { forwardRef, useRef, useState } from 'react';
+import {
+  ChangeEvent,
+  Dispatch,
+  forwardRef,
+  SetStateAction,
+  useRef,
+  useState,
+} from 'react';
 import { MemoSize, SIZE_CONFIG } from './Memo';
 
 const TEXTAREA_PADDING = 24;
@@ -52,10 +59,19 @@ type Dimensions = {
   height: number;
 };
 
+// 글자수 초과 시 렌더되는 alert 컴포넌트
+const TextLimitAlert = (): JSX.Element => {
+  return (
+    <span className='block pt-5 text-center text-xs font-medium text-red-200'>
+      글자 수를 초과하여 더 입력할 수 없습니다.
+    </span>
+  );
+};
+
 interface MemoTextareaProps {
   text: string;
   size: MemoSize;
-  setMemoText: (text: string) => void;
+  setMemoText: Dispatch<SetStateAction<string>>;
   className?: string;
 }
 
@@ -66,8 +82,9 @@ const MemoTextarea = forwardRef<HTMLTextAreaElement, MemoTextareaProps>(
       width: SIZE_CONFIG[size].minWidth,
       height: SIZE_CONFIG[size].minHeight,
     });
+    const [isMaxText, setIsMaxText] = useState(false);
 
-    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
       const newValue = e.target.value;
 
       if (!textareaRef.current) {
@@ -102,31 +119,36 @@ const MemoTextarea = forwardRef<HTMLTextAreaElement, MemoTextareaProps>(
 
       // 최대 너비와 최대 높이 보다 큰 영역을 차지하는 경우 반환 (텍스트 입력 불가)
       if (newWidth >= maxWidth && textHeight > maxTextHeight) {
+        setIsMaxText(true);
         return;
       }
       if (textHeight > maxTextHeight) {
         return;
       }
       setMemoText(newValue);
+      setIsMaxText(false);
     };
 
     return (
-      <textarea
-        ref={ref || textareaRef}
-        value={text}
-        onChange={handleChange}
-        placeholder='메모...'
-        className={`${className} resize-none overflow-hidden`}
-        style={{
-          width: `${dimensions.width}px`,
-          height: `${dimensions.height}px`,
-          whiteSpace:
-            dimensions.width >= SIZE_CONFIG[size].maxWidth
-              ? 'pre-wrap'
-              : 'nowrap',
-        }}
-        {...props}
-      />
+      <>
+        <textarea
+          ref={ref || textareaRef}
+          value={text}
+          onChange={handleChange}
+          placeholder='메모...'
+          className={`${className} resize-none overflow-hidden`}
+          style={{
+            width: `${dimensions.width}px`,
+            height: `${dimensions.height}px`,
+            whiteSpace:
+              dimensions.width >= SIZE_CONFIG[size].maxWidth
+                ? 'pre-wrap'
+                : 'nowrap',
+          }}
+          {...props}
+        />
+        {isMaxText && <TextLimitAlert />}
+      </>
     );
   },
 );

--- a/src/components/atoms/memo/MemoTextarea.tsx
+++ b/src/components/atoms/memo/MemoTextarea.tsx
@@ -1,11 +1,5 @@
-import {
-  ChangeEvent,
-  Dispatch,
-  forwardRef,
-  SetStateAction,
-  useRef,
-  useState,
-} from 'react';
+import useMemoContext from '@/contexts/memo/MemoContext';
+import { ChangeEvent, forwardRef, useRef, useState } from 'react';
 import { MemoSize, SIZE_CONFIG } from './Memo';
 
 const TEXTAREA_PADDING = 24;
@@ -71,18 +65,18 @@ const TextLimitAlert = (): JSX.Element => {
 interface MemoTextareaProps {
   text: string;
   size: MemoSize;
-  setMemoText: Dispatch<SetStateAction<string>>;
   className?: string;
 }
 
 const MemoTextarea = forwardRef<HTMLTextAreaElement, MemoTextareaProps>(
-  ({ text, size, setMemoText, className, ...props }, ref) => {
+  ({ size, className, ...props }, ref) => {
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const [dimensions, setDimensions] = useState<Dimensions>({
       width: SIZE_CONFIG[size].minWidth,
       height: SIZE_CONFIG[size].minHeight,
     });
     const [isMaxText, setIsMaxText] = useState(false);
+    const { memoText, setMemoText } = useMemoContext();
 
     const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
       const newValue = e.target.value;
@@ -133,7 +127,7 @@ const MemoTextarea = forwardRef<HTMLTextAreaElement, MemoTextareaProps>(
       <>
         <textarea
           ref={ref || textareaRef}
-          value={text}
+          value={memoText}
           onChange={handleChange}
           placeholder='메모...'
           className={`${className} resize-none overflow-hidden`}

--- a/src/components/atoms/memo/SubmitButton.tsx
+++ b/src/components/atoms/memo/SubmitButton.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@/components/atoms/button';
+import { useRouter } from 'next/navigation';
+import { Dispatch, SetStateAction } from 'react';
+
+interface SubmitButtonProps {
+  text?: string;
+  setMemoText: Dispatch<SetStateAction<string>>;
+}
+
+// textarea 하위 버튼 컴포넌트
+const SubmitButton = ({
+  text,
+  setMemoText,
+}: SubmitButtonProps): JSX.Element => {
+  const router = useRouter();
+
+  const handleClick = () => {
+    setMemoText(text || '');
+    // TODO : user 정보 받아오기
+    router.push('/home/user1');
+  };
+
+  return (
+    <Button
+      onClick={handleClick}
+      variant={text ? 'primary_fill' : 'gray_fill'}
+      size='lg'
+      width='register'
+      className={`${!text && 'pointer-events-none'} absolute bottom-[34px]`}
+    >
+      메모 등록하기
+    </Button>
+  );
+};
+
+export default SubmitButton;

--- a/src/components/atoms/memo/SubmitButton.tsx
+++ b/src/components/atoms/memo/SubmitButton.tsx
@@ -1,21 +1,14 @@
 import { Button } from '@/components/atoms/button';
+import useMemoContext from '@/contexts/memo/MemoContext';
 import { useRouter } from 'next/navigation';
-import { Dispatch, SetStateAction } from 'react';
-
-interface SubmitButtonProps {
-  text?: string;
-  setMemoText: Dispatch<SetStateAction<string>>;
-}
 
 // textarea 하위 버튼 컴포넌트
-const SubmitButton = ({
-  text,
-  setMemoText,
-}: SubmitButtonProps): JSX.Element => {
+const SubmitButton = (): JSX.Element => {
   const router = useRouter();
+  const { memoText, setMemoText } = useMemoContext();
 
   const handleClick = () => {
-    setMemoText(text || '');
+    setMemoText(memoText || '');
     // TODO : user 정보 받아오기
     router.push('/home/user1');
   };
@@ -23,10 +16,10 @@ const SubmitButton = ({
   return (
     <Button
       onClick={handleClick}
-      variant={text ? 'primary_fill' : 'gray_fill'}
+      variant={memoText ? 'primary_fill' : 'gray_fill'}
       size='lg'
       width='register'
-      className={`${!text && 'pointer-events-none'} absolute bottom-[34px]`}
+      className={`${!memoText && 'pointer-events-none'} absolute bottom-[34px]`}
     >
       메모 등록하기
     </Button>

--- a/src/components/molecules/MemoContent.tsx
+++ b/src/components/molecules/MemoContent.tsx
@@ -8,7 +8,7 @@ interface MemoContnetProps {
 
 export const MemoContnet = ({ imgUrl = '' }: MemoContnetProps) => {
   return (
-    <div className='mt-[72px] flex flex-col items-center -space-y-1'>
+    <div className='flex flex-col items-center -space-y-1 pt-[80px]'>
       <Profile size='large' />
       <Memo size='medium' isEditMode />
     </div>

--- a/src/components/molecules/memo/MemoContent.tsx
+++ b/src/components/molecules/memo/MemoContent.tsx
@@ -1,12 +1,12 @@
 import { Memo } from '@/components/atoms/memo/Memo';
 import { Profile } from '@/components/atoms/profile/Profile';
 
-interface MemoContnetProps {
+interface MemoContentProps {
   // 서버로 부터 받아올 이미지
   imgUrl?: string;
 }
 
-export const MemoContnet = ({ imgUrl = '' }: MemoContnetProps): JSX.Element => {
+export const MemoContent = ({ imgUrl = '' }: MemoContentProps): JSX.Element => {
   return (
     <div className='flex flex-col items-center -space-y-1 pt-[80px]'>
       <Profile size='large' />

--- a/src/components/molecules/memo/MemoContent.tsx
+++ b/src/components/molecules/memo/MemoContent.tsx
@@ -6,7 +6,7 @@ interface MemoContnetProps {
   imgUrl?: string;
 }
 
-export const MemoContnet = ({ imgUrl = '' }: MemoContnetProps) => {
+export const MemoContnet = ({ imgUrl = '' }: MemoContnetProps): JSX.Element => {
   return (
     <div className='flex flex-col items-center -space-y-1 pt-[80px]'>
       <Profile size='large' />

--- a/src/components/molecules/memo/MemoLink.tsx
+++ b/src/components/molecules/memo/MemoLink.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+
+import { Memo } from '@/components/atoms/memo/Memo';
+import { Profile } from '@/components/atoms/profile/Profile';
+
+export const MemoLink = () => {
+  const username = 'test'; // dummy data
+
+  return (
+    <div className='flex flex-row items-center justify-center'>
+      {/* TODO: 레이아웃 수정 필요 */}
+      {['예신', '예랑'].map((role) => (
+        <Link key={role} href={`/memo/${username}?role=${role}`}>
+          <div className='flex flex-col items-center -space-y-1'>
+            <Profile size='medium' />
+            <Memo size='small' />
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
+};
+
+export default MemoLink;

--- a/src/constants/memo/memoConstants.ts
+++ b/src/constants/memo/memoConstants.ts
@@ -1,0 +1,16 @@
+// 메모 기능에서 사용하는 상수들을 정의힙니다.
+
+import { MemoSize } from '@/types/memo/memoTypes';
+
+export const TEXTAREA_PADDING = 24;
+
+// 메모 크기별 최대 텍스트 높이 설정
+export const MAX_TEXT_HEIGHT: Record<MemoSize, number> = {
+  small: 51,
+  medium: 56,
+};
+
+export const HEIGHT_PADDING: Record<MemoSize, number> = {
+  small: 2,
+  medium: 1,
+};

--- a/src/contexts/memo/MemoContext.ts
+++ b/src/contexts/memo/MemoContext.ts
@@ -1,0 +1,23 @@
+import { createContext, useContext } from 'react';
+
+interface MemoContextProps {
+  memoText: string;
+  setMemoText: (text: string) => void;
+}
+
+export const MemoContext = createContext<MemoContextProps | undefined>(
+  undefined,
+);
+
+// MemoContext 사용을 위한 Hook
+export const useMemoContext = () => {
+  const context = useContext(MemoContext);
+  if (!context) {
+    throw new Error(
+      'MemoContext를 사용할 수 없습니다. MemoProvider를 감싸주세요.',
+    );
+  }
+  return context;
+};
+
+export default useMemoContext;

--- a/src/contexts/memo/MemoProvider.tsx
+++ b/src/contexts/memo/MemoProvider.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { ReactNode, useState } from 'react';
+import { MemoContext } from './MemoContext';
+
+export const MemoProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}): JSX.Element => {
+  // TODO: 서버에서 memoText 받아오기 (현재는 기본값 '')
+  const [memoText, setMemoText] = useState('');
+
+  return (
+    <MemoContext.Provider value={{ memoText, setMemoText }}>
+      {children}
+    </MemoContext.Provider>
+  );
+};

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -1,26 +1,11 @@
-import Link from 'next/link';
-
-import { Memo } from '@/components/atoms/memo/Memo';
-import { Profile } from '@/components/atoms/profile/Profile';
+import MemoLink from '@/components/molecules/memo/MemoLink';
 import { Navigation } from '@/components/molecules/navigation';
 
 export const Home = () => {
-  const username = 'test'; // dummy data
-
   return (
     <div className='relative flex h-full w-full flex-col'>
       <Navigation />
-      {/* TODO: 레이아웃 수정 필요 */}
-      <div className='flex flex-row items-center justify-center'>
-        {['예신', '예랑'].map((role) => (
-          <Link key={role} href={`/memo/${username}?role=${role}`}>
-            <div className='flex flex-col items-center -space-y-1'>
-              <Profile size='medium' />
-              <Memo size='small' />
-            </div>
-          </Link>
-        ))}
-      </div>
+      <MemoLink />
     </div>
   );
 };

--- a/src/features/memo/Memo.tsx
+++ b/src/features/memo/Memo.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MemoContnet } from '@/components/molecules/MemoContent';
+import { MemoContnet } from '@/components/molecules/memo/MemoContent';
 import { useSearchParams } from 'next/navigation';
 
 export const Memo = () => {

--- a/src/features/memo/Memo.tsx
+++ b/src/features/memo/Memo.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MemoContnet } from '@/components/molecules/memo/MemoContent';
+import { MemoContent } from '@/components/molecules/memo/MemoContent';
 import { useSearchParams } from 'next/navigation';
 
 export const Memo = () => {
@@ -19,7 +19,7 @@ export const Memo = () => {
       <p className='mt-4 text-sm font-medium text-gray-700'>
         메모는 24시간 동안 유지되어요.
       </p>
-      <MemoContnet />
+      <MemoContent />
     </div>
   );
 };

--- a/src/types/memo/memoTypes.ts
+++ b/src/types/memo/memoTypes.ts
@@ -1,0 +1,30 @@
+// 메모 기능에서 사용하는 타입들을 정의힙니다.
+
+export type MemoSize = 'small' | 'medium';
+
+type SizeConfigItem = {
+  minWidth: number;
+  maxWidth: number;
+  minHeight: number;
+  maxHeight: number;
+};
+
+// 정의된 size에 따른 최대/최소 크기 정보
+export const SIZE_CONFIG: Record<MemoSize, SizeConfigItem> = {
+  small: { minWidth: 58, maxWidth: 155, minHeight: 34, maxHeight: 52 },
+  medium: { minWidth: 63, maxWidth: 173, minHeight: 37, maxHeight: 58 },
+};
+
+// textarea 사이즈 타입
+export type Dimensions = {
+  width: number;
+  height: number;
+};
+
+// textarea의 크기를 업데이트 한 후 반환되는 타입
+export type UpdateDimensions = {
+  width: number;
+  height: number;
+  textHeight: number;
+  maxTextHeight: number;
+};

--- a/src/utils/memo/memoUtils.ts
+++ b/src/utils/memo/memoUtils.ts
@@ -1,0 +1,77 @@
+// 메모 기능에서 사용하는 util 함수들을 정의힙니다.
+
+import {
+  HEIGHT_PADDING,
+  MAX_TEXT_HEIGHT,
+  TEXTAREA_PADDING,
+} from '@/constants/memo/memoConstants';
+import {
+  MemoSize,
+  SIZE_CONFIG,
+  UpdateDimensions,
+} from '@/types/memo/memoTypes';
+
+// 텍스트의 크기를 계산하기 위한 임시 span 요소 생성 함수
+const createTempSpan = (
+  context: HTMLTextAreaElement,
+  newValue: string,
+): HTMLSpanElement => {
+  const tempSpan = document.createElement('span');
+  tempSpan.style.visibility = 'hidden';
+  tempSpan.style.position = 'absolute';
+  tempSpan.style.whiteSpace = 'pre';
+  tempSpan.style.font = window.getComputedStyle(context).font;
+  tempSpan.textContent = newValue || ' ';
+  document.body.appendChild(tempSpan);
+  return tempSpan;
+};
+
+const calculateNewHeight = (
+  calculatedWidth: number,
+  textHeight: number,
+  maxTextHeight: number,
+  size: MemoSize,
+): number => {
+  const { maxWidth, minHeight, maxHeight } = SIZE_CONFIG[size];
+
+  // 최대 너비를 초과하면 최대 높이 반환
+  if (calculatedWidth >= maxWidth) {
+    return maxHeight;
+  }
+  // 최대 높이를 초과하면 최대 높이를 제한
+  if (textHeight >= maxTextHeight) {
+    return Math.min(textHeight + HEIGHT_PADDING[size], maxHeight);
+  }
+  return minHeight;
+};
+
+export const updateDimensions = (
+  context: HTMLTextAreaElement,
+  text: string,
+  size: MemoSize,
+): UpdateDimensions => {
+  const { minWidth, maxWidth } = SIZE_CONFIG[size];
+
+  const tempSpan = createTempSpan(context, text);
+  const calculatedWidth = Math.min(
+    tempSpan.offsetWidth + TEXTAREA_PADDING,
+    maxWidth,
+  );
+  document.body.removeChild(tempSpan);
+
+  const textHeight = context.scrollHeight || 0;
+  const maxTextHeight = MAX_TEXT_HEIGHT[size];
+  const newHeight = calculateNewHeight(
+    calculatedWidth,
+    textHeight,
+    maxTextHeight,
+    size,
+  );
+
+  return {
+    width: Math.max(calculatedWidth, minWidth),
+    height: newHeight,
+    textHeight,
+    maxTextHeight,
+  };
+};


### PR DESCRIPTION
## Motivation 🤔
- 메모 관련 데이터 전역 관리
- 글자수 제한 Alert, 메모 등록 기능 추가
- MemoLink 분리
- Memo용 utils, types, constants 폴더 생성 및 분리
- TODO:  역할별 메모 저장 및 편집

## Key Changes 🔑
### 1️⃣ **MemoContext 및 MemoProvider 구현**
- `MemoContext`를 생성하여 `memoText` 상태를 관리
- `MemoProvider`를 통해 `memoText` 상태를 전역적으로 공유하도록 처리

### 2️⃣ **글자수 제한 Alert 기능 추가**
- 글자수가 영역의 크기를 초과하면 Alert 메시지를 표시하는 컴포넌트 구현

### 3️⃣ **메모 등록 버튼 추가 및 동작 처리**
- 메모 등록 후 `home` 페이지로 이동하도록 라우팅 처리

### 4️⃣ **MemoLink 컴포넌트 분리**
- `MemoLink`를 별도 컴포넌트로 분리하여 구조 개선
- 역할별 메모 관리 기능 추가 **예정**

### 5️⃣ **초기 렌더링 시 크기 설정 로직 추가**
- memo text가 있는 경우 textarea의 크기를 계산하여 반영함



**🛠 TODO**
- 역할별 메모 개별 업데이트 기능 구현  
- 역할에 따라 다른 `memoText`를 저장하고 렌더링하도록 개선  
- 현재 유저 정보 활용하여 접근 제어 추가  

## Attachment 📷

