### PR TITLE
[feat] 카테고리 및 달력, 담당자 선택 컴포넌트 구현

### DIFF
--- a/src/components/molecules/calendarSelect/CalendarSelect.tsx
+++ b/src/components/molecules/calendarSelect/CalendarSelect.tsx
@@ -1,71 +1,61 @@
-'use client';
-
-import { useState } from 'react';
 import Calendar from 'react-calendar';
-import { format } from 'date-fns';
+import { format, parse } from 'date-fns';
 import LeftArrow from '@/assets/left_arrow.svg';
 import RightArrow from '@/assets/right_arrow.svg';
 
 import './styles.css';
 
-export type DatePiece = Date | null;
-export type SelectedDate = DatePiece | [DatePiece, DatePiece];
+type DatePiece = Date | null;
+type SelectedDate = DatePiece | [DatePiece, DatePiece];
 
-export const CalendarSelect = () => {
-  const [selectedDate, setSelectedDate] = useState<SelectedDate>(null);
-  const [isFolded, setIsFolded] = useState<boolean>(false);
+const CalendarNavButton = ({ direction }: { direction: 'left' | 'right' }) => {
+  const isLeft = direction === 'left';
+  return (
+    <div
+      className={`mb-5 flex h-6 w-6 items-center justify-center ${isLeft ? 'mr-1' : 'ml-1'}`}
+    >
+      {isLeft ? <LeftArrow /> : <RightArrow />}
+    </div>
+  );
+};
 
-  const handleSelectedDate = (newDate: SelectedDate) => {
+interface CalendarSelectProps {
+  selectedDate: string | null;
+  setSelectedDate: (selected: string | null) => void;
+  setIsFolded: (isFolded: boolean) => void;
+}
+
+export const CalendarSelect = ({
+  selectedDate,
+  setSelectedDate,
+  setIsFolded,
+}: CalendarSelectProps): JSX.Element => {
+  const parsedSelectedDate = selectedDate
+    ? parse(selectedDate, 'yyyy.MM.dd', new Date())
+    : null;
+
+  const handleSelect = (newDate: SelectedDate) => {
     if (!(newDate instanceof Date)) return;
 
-    const isSameDate =
-      selectedDate instanceof Date &&
-      selectedDate.getTime() === newDate.getTime();
-
-    setSelectedDate(isSameDate ? null : newDate);
-    setIsFolded((prev) => !prev);
+    const isSameDate = parsedSelectedDate?.getTime() === newDate.getTime();
+    setSelectedDate(isSameDate ? null : format(newDate, 'yyyy.MM.dd'));
+    setIsFolded(false);
   };
 
   return (
-    <div className='rounded-lg bg-gray-100 p-5'>
-      <div
-        className='flex cursor-pointer justify-between text-base font-medium'
-        onClick={() => setIsFolded(true)}
-      >
-        <span className='text-gray-800'>날짜</span>
-        <span className={`${selectedDate ? 'text-white' : 'text-gray-500'}`}>
-          {selectedDate instanceof Date
-            ? format(selectedDate, 'yyyy년 M월 d일')
-            : '선택 안함'}
-        </span>
-      </div>
-
-      {isFolded && (
-        <Calendar
-          className='react-calendar'
-          onChange={handleSelectedDate}
-          value={selectedDate}
-          view='month'
-          calendarType='gregory'
-          prev2Label={null}
-          next2Label={null}
-          showNeighboringMonth={false}
-          formatDay={(_, date) => format(date, 'd')}
-          prevLabel={
-            <div className='mb-5 mr-1 flex h-6 w-6 items-center justify-center'>
-              <LeftArrow />
-            </div>
-          }
-          nextLabel={
-            <div className='ml-1 flex h-6 w-6 items-center justify-center'>
-              <RightArrow />
-            </div>
-          }
-          tileClassName={({ date }) =>
-            date < new Date() ? 'text-gray-400' : ''
-          }
-        />
-      )}
-    </div>
+    <Calendar
+      className='react-calendar'
+      onChange={handleSelect}
+      value={parsedSelectedDate}
+      view='month'
+      calendarType='gregory'
+      prev2Label={null}
+      next2Label={null}
+      showNeighboringMonth={false}
+      formatDay={(_, date) => format(date, 'd')}
+      prevLabel={<CalendarNavButton direction='left' />}
+      nextLabel={<CalendarNavButton direction='right' />}
+      tileClassName={({ date }) => (date < new Date() ? 'text-gray-400' : '')}
+    />
   );
 };

--- a/src/components/molecules/categorySelect/CategorySelect.tsx
+++ b/src/components/molecules/categorySelect/CategorySelect.tsx
@@ -1,0 +1,41 @@
+import { Button } from '@/components/atoms/button';
+
+interface CategorySelectProps {
+  categoryArray: string[];
+  selectedCategory: string | null;
+  setSelectedCategory: (selected: string | null) => void;
+  setIsFolded: (isFolded: boolean) => void;
+}
+
+export const CategorySelect = ({
+  categoryArray,
+  selectedCategory,
+  setSelectedCategory,
+  setIsFolded,
+}: CategorySelectProps) => {
+  const handleSelect = (category: string) => {
+    const isSameDate = category === selectedCategory;
+    setSelectedCategory(isSameDate ? null : category);
+    setIsFolded(false);
+  };
+
+  return (
+    <div className='mt-5 grid grid-cols-2 gap-3'>
+      {categoryArray.map((category) => {
+        return (
+          <Button
+            key={category}
+            className='text-sm'
+            height={'md'}
+            variant={
+              selectedCategory === category ? 'primary_fill' : 'gray_fill'
+            }
+            onClick={() => handleSelect(category)}
+          >
+            {category}
+          </Button>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/molecules/categorySelect/index.ts
+++ b/src/components/molecules/categorySelect/index.ts
@@ -1,0 +1,1 @@
+export { CategorySelect } from '@/components/molecules/categorySelect/CategorySelect';

--- a/src/components/molecules/foldableSelector/FoldableSelector.stories.tsx
+++ b/src/components/molecules/foldableSelector/FoldableSelector.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { FoldableSelector } from './FoldableSelector';
+import { useState } from 'react';
+
+const meta: Meta<typeof FoldableSelector> = {
+  title: 'Components/FoldableSelector',
+  component: FoldableSelector,
+};
+
+export default meta;
+type Story = StoryObj<typeof FoldableSelector>;
+
+export const CalendarSelect: Story = {
+  args: {
+    selectedValue: null,
+  },
+  render: (args) => {
+    const [date, setDate] = useState<string | null>(args.selectedValue);
+    return (
+      <div className='w-96'>
+        <FoldableSelector selectedValue={date} setSelectedValue={setDate} />
+      </div>
+    );
+  },
+};
+
+export const CategorySelector: Story = {
+  args: {
+    categoryArray: [
+      '스튜디오 촬영하기',
+      '스냅 촬영하기',
+      '드레스/정장',
+      '메이크업',
+      '외모 관리',
+      '결혼식 구성 준비',
+    ],
+    selectedValue: null,
+  },
+  render: (args) => {
+    const [date, setDate] = useState<string | null>(args.selectedValue);
+    return (
+      <div className='w-96'>
+        <FoldableSelector
+          {...args}
+          selectedValue={date}
+          setSelectedValue={setDate}
+        />
+      </div>
+    );
+  },
+};

--- a/src/components/molecules/foldableSelector/FoldableSelector.tsx
+++ b/src/components/molecules/foldableSelector/FoldableSelector.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { CategorySelect } from '@/components/molecules/categorySelect';
+import { CalendarSelect } from '@/components/molecules/calendarSelect';
+
+interface FoldableSelectorProps {
+  categoryArray?: string[];
+  selectedValue: string | null;
+  setSelectedValue: (value: string | null) => void;
+}
+
+export const FoldableSelector = ({
+  categoryArray,
+  selectedValue,
+  setSelectedValue,
+}: FoldableSelectorProps) => {
+  const [isFolded, setIsFolded] = useState<boolean>(false);
+
+  return (
+    <div className='w-full rounded-lg bg-gray-100 p-5'>
+      <div
+        className='flex cursor-pointer justify-between text-base font-medium'
+        onClick={() => setIsFolded(true)}
+      >
+        <span className='font-medium text-white'>
+          {categoryArray ? '카테고리' : '날짜'}
+        </span>
+        <span className={`${selectedValue ? 'text-white' : 'text-gray-500'}`}>
+          {selectedValue ?? '선택 안함'}
+        </span>
+      </div>
+
+      {isFolded &&
+        (categoryArray ? (
+          <CategorySelect
+            categoryArray={categoryArray}
+            selectedCategory={selectedValue}
+            setSelectedCategory={setSelectedValue}
+            setIsFolded={setIsFolded}
+          />
+        ) : (
+          <CalendarSelect
+            selectedDate={selectedValue}
+            setSelectedDate={setSelectedValue}
+            setIsFolded={setIsFolded}
+          />
+        ))}
+    </div>
+  );
+};

--- a/src/components/molecules/foldableSelector/index.ts
+++ b/src/components/molecules/foldableSelector/index.ts
@@ -1,0 +1,1 @@
+export { FoldableSelector } from '@/components/molecules/foldableSelector/FoldableSelector';

--- a/src/components/molecules/managerSelect/ManagerSelect.tsx
+++ b/src/components/molecules/managerSelect/ManagerSelect.tsx
@@ -1,0 +1,32 @@
+interface ManagerSelectProps {
+  selectedValue: string;
+  setSelectedValue: (value: string) => void;
+}
+
+const managerMap = [
+  { name: '함께', bgColor: 'bg-primary-400' },
+  { name: '예신', bgColor: 'bg-pink' },
+  { name: '예랑', bgColor: 'bg-blue' },
+];
+
+export const ManagerSelect = ({
+  selectedValue,
+  setSelectedValue,
+}: ManagerSelectProps) => {
+  return (
+    <div className='flex w-full items-center justify-between rounded-lg bg-gray-100 p-5'>
+      <span className='font-medium text-white'>담당자</span>
+      <div className='flex gap-2'>
+        {managerMap.map(({ name, bgColor }) => (
+          <div
+            key={name}
+            className={`flex h-8 w-[52px] cursor-pointer items-center justify-center rounded-full ${name === selectedValue ? `text-white ${bgColor}` : 'bg-gray-200 text-gray-500'} `}
+            onClick={() => setSelectedValue(name)}
+          >
+            {name}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/molecules/managerSelect/index.ts
+++ b/src/components/molecules/managerSelect/index.ts
@@ -1,0 +1,1 @@
+export { ManagerSelect } from '@/components/molecules/managerSelect/ManagerSelect';


### PR DESCRIPTION
## Motivation 🤔
![image](https://github.com/user-attachments/assets/e5a0ce29-6d73-4b8f-afa8-2e9348b77ca3)

## Key Changes 🔑
`FoldableSelector` 컴포넌트 구현
* `CategorySelect`와 `CalendarSelect`를 포함하는 컴포넌트로, **fold on/off** 기능 제공
* `categoryArray`가 존재하면 카테고리 선택, 없으면 날짜 선택 기능 제공

`CategorySelect` 컴포넌트 구현
* 카테고리 선택을 위한 `CategorySelect` 컴포넌트 구현
* `categoryArray`를 props로 받아 동적으로 버튼 리스트 생성
* 선택된 카테고리가 동일하면 해제, 새로운 값이면 변경하도록 로직 추가
* `setIsFolded(false)` 호출하여 선택 후 `FoldableSelector`가 닫히도록 처리

`CalendarSelect` fold 기능 제거 및 props 구조 개선
- fold 상태 및 toggle 기능 제거 후 상위에서 제어하도록 변경
- `selectedDate`를 string 형식으로 받도록 수정(yyyy.mm.dd)
- `setSelectedDate`, `setisFolded` 를 props로 전달받아 상태 변경을 상위에서 관리
- `CalendarNavButton` 컴포넌트로 네비게이션 버튼 분리

`ManagerSelect` 컴포넌트 구현
- 담당자 선택 기능을 제공하는 `ManagerSelect` 컴포넌트 구현
- 추후 Button 컴포넌트 가이드 업데이트 시 공통 Button 컴포넌트로 변경 필요

## Attachment 📷
![image](https://github.com/user-attachments/assets/1ff36ff0-1c9a-4924-b0e4-9a76e9864858)
