### PR TITLE
[refactor] TextInput, TextArea 컴포넌트 리팩토링

### DIFF
--- a/src/components/atoms/textArea/TextArea.tsx
+++ b/src/components/atoms/textArea/TextArea.tsx
@@ -1,8 +1,9 @@
-import { cva } from 'class-variance-authority';
 import { ChangeEvent, forwardRef } from 'react';
+import { cva } from 'class-variance-authority';
+import { isValidText } from '@/utils/validation';
 
-const textAreaVariants = cva(
-  'h-[105px] w-full resize-none overflow-hidden text-ellipsis bg-transparent focus:outline-none focus:ring-0',
+export const textAreaVariants = cva(
+  'w-full resize-none overflow-hidden text-ellipsis bg-transparent leading-5 focus:outline-none focus:ring-0',
   {
     variants: {
       variant: {
@@ -24,15 +25,20 @@ interface TextAreaProps {
 }
 
 export const TextArea = forwardRef<HTMLDivElement, TextAreaProps>(
-  ({ value, onChange, maxLength = 100, placeholder, ...props }, ref) => {
+  ({ value, onChange, maxLength, placeholder, ...props }, ref) => {
     const handleOnChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
       const { value } = event.target;
 
-      onChange(value);
+      if (
+        value === '' ||
+        (isValidText(value) && (!maxLength || value.length <= maxLength))
+      ) {
+        onChange(value);
+      }
     };
 
     return (
-      <div ref={ref} className='w-[350px] gap-2 rounded-lg bg-gray-100 p-5'>
+      <div ref={ref} className='w-full gap-2 rounded-lg bg-gray-100 p-5'>
         <textarea
           value={value}
           onChange={handleOnChange}
@@ -43,9 +49,12 @@ export const TextArea = forwardRef<HTMLDivElement, TextAreaProps>(
           })}
           {...props}
         />
-        <span
-          className={`flex justify-end text-[14px] ${value.trim() ? 'text-gray-600' : 'text-gray-400'}`}
-        >{`${value.length}/${maxLength}`}</span>
+
+        {maxLength && (
+          <span
+            className={`flex justify-end text-[14px] leading-[18px] ${value.trim() ? 'text-gray-600' : 'text-gray-400'}`}
+          >{`${value.length}/${maxLength}`}</span>
+        )}
       </div>
     );
   },

--- a/src/components/atoms/textInput/TextInput.tsx
+++ b/src/components/atoms/textInput/TextInput.tsx
@@ -25,11 +25,14 @@ interface TextInputProps {
 }
 
 export const TextInput = forwardRef<HTMLDivElement, TextInputProps>(
-  ({ value, onChange, maxLength = 18, placeholder, ...props }, ref) => {
+  ({ value, onChange, maxLength, placeholder, ...props }, ref) => {
     const handleOnChange = (event: ChangeEvent<HTMLInputElement>) => {
       const { value } = event.target;
 
-      if (value === '' || (isValidText(value) && value.length <= maxLength)) {
+      if (
+        value === '' ||
+        (isValidText(value) && (!maxLength || value.length <= maxLength))
+      ) {
         onChange(value);
       }
     };
@@ -37,7 +40,7 @@ export const TextInput = forwardRef<HTMLDivElement, TextInputProps>(
     return (
       <div
         ref={ref}
-        className='flex w-[350px] items-center justify-between gap-[38px] rounded-lg bg-gray-100 p-5'
+        className='flex w-full items-center justify-between gap-[38px] rounded-lg bg-gray-100 p-5'
       >
         <input
           type='text'
@@ -50,9 +53,12 @@ export const TextInput = forwardRef<HTMLDivElement, TextInputProps>(
           })}
           {...props}
         />
-        <span
-          className={`text-[14px] ${value.trim() ? 'text-gray-600' : 'text-gray-400'}`}
-        >{`${value.length}/${maxLength}`}</span>
+
+        {maxLength && (
+          <span
+            className={`text-[14px] ${value.trim() ? 'text-gray-600' : 'text-gray-400'}`}
+          >{`${value.length}/${maxLength}`}</span>
+        )}
       </div>
     );
   },

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,5 +1,5 @@
-// 한글, 영어, 숫자, 공백만 허용하는 정규식
-const validTextRegExp = /^[\p{L}\p{N}\s]+$/u;
+// 한글, 영어, 숫자, 공백(' ')만 허용하는 정규식
+const validTextRegExp = /^[\p{L}\p{N} ]+$/u;
 
 export const isValidText = (input: string) => {
   return validTextRegExp.test(input);


### PR DESCRIPTION
## Motivation 🤔
- TextArea 컴포넌트의 입력값 검증 로직 추가 필요
- TextInput, TextArea 컴포넌트에 `maxLength`가 설정되지 않았을 때 글자 수 표시 UI 보여지지 않도록 하는 기능 필요

## Key Changes 🔑
TextInput `maxLength` 처리 로직 개선
- `maxLength`를 정의했을 때만 글자 수 표시되도록 개선
- textInput div의 스타일을 w-full로 적용하여 가변적인 너비 대응

TextArea `maxLength` 처리 및 입력값 검증 로직 추가
- `maxLength`가 설정되었을 때 글자 수 표시되도록 개선
- `isValidText` 함수를 통해 입력값 검증 로직 추가
- `w-full`로 변경하여 유연한 너비 조정 가능하도록 처리
- 그 밖 style 추가

`isValidText` 정규식 개선
- /s 대신 ' ' 공백만 허용하도록 정규식 개선
- 줄바꿈 공백은 허용하지 않음

## Attachment 📷
