### PR TITLE
[chore] Storybook addon/design 추가

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,10 +12,11 @@ function getAbsolutePath(value: string): any {
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: [
-    getAbsolutePath('@storybook/addon-onboarding'),
-    getAbsolutePath('@storybook/addon-essentials'),
-    getAbsolutePath('@chromatic-com/storybook'),
-    getAbsolutePath('@storybook/addon-interactions'),
+    '@storybook/addon-onboarding',
+    '@storybook/addon-essentials',
+    '@chromatic-com/storybook',
+    '@storybook/addon-interactions',
+    '@storybook/addon-designs',
   ],
   framework: {
     name: getAbsolutePath('@storybook/nextjs'),

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@chromatic-com/storybook": "^3.2.2",
     "@commitlint/cli": "^19.7.1",
     "@commitlint/config-conventional": "^19.7.1",
+    "@storybook/addon-designs": "^8.2.0",
     "@storybook/addon-essentials": "^8.5.2",
     "@storybook/addon-interactions": "^8.5.2",
     "@storybook/addon-onboarding": "^8.5.2",

--- a/src/components/atoms/modal/Modal.stories.tsx
+++ b/src/components/atoms/modal/Modal.stories.tsx
@@ -13,16 +13,16 @@ type Story = StoryObj<typeof Modal>;
 export const BasicModal: Story = {
   args: {
     children: (
-      <div className='flex flex-col justify-center items-center w-[320px]'>
-        <span className='text-white text-lg'>Title</span>
+      <div className='flex w-[320px] flex-col items-center justify-center'>
+        <span className='text-lg text-white'>Title</span>
 
-        <span className='text-gray-700 text-sm pt-3 pb-5'>Description</span>
+        <span className='pb-5 pt-3 text-sm text-gray-700'>Description</span>
 
         <div className='flex w-full justify-center gap-4'>
-          <button className='w-[130px] h-[52px] rounded-md bg-gray-300 text-gray-800'>
+          <button className='h-[52px] w-[130px] rounded-md bg-gray-300 text-gray-800'>
             Text
           </button>
-          <button className='w-[130px] h-[52px] rounded-md bg-red-200 text-white'>
+          <button className='h-[52px] w-[130px] rounded-md bg-red-200 text-white'>
             Text
           </button>
         </div>
@@ -31,20 +31,34 @@ export const BasicModal: Story = {
   },
 };
 
+BasicModal.parameters = {
+  design: {
+    type: 'figma',
+    url: 'https://www.figma.com/file/cr2DuY0vceiMI5LlqWdKR2/Wedvice_%EB%94%94%EC%9E%90%EC%9D%B8?node-id=1403-38040&t=st8bJ1H7LQ9alnmh-4',
+  },
+};
+
 export const ConfirmModal: Story = {
   args: {
     children: (
-      <div className='flex flex-col justify-center w-[330px]'>
-        <span className='text-white font-bold text-lg'>Title</span>
+      <div className='flex w-[330px] flex-col justify-center'>
+        <span className='text-lg font-bold text-white'>Title</span>
 
-        <span className='text-gray-700 text-sm pt-3 pb-5'>Description</span>
+        <span className='pb-5 pt-3 text-sm text-gray-700'>Description</span>
 
         <div className='flex w-full justify-end gap-4'>
-          <button className='w-[56px] h-[34px] rounded-md bg-gray-300 text-gray-800'>
+          <button className='h-[34px] w-[56px] rounded-md bg-gray-300 text-gray-800'>
             Text
           </button>
         </div>
       </div>
     ),
+  },
+};
+
+ConfirmModal.parameters = {
+  design: {
+    type: 'figma',
+    url: 'https://www.figma.com/design/cr2DuY0vceiMI5LlqWdKR2/Wedvice_%EB%94%94%EC%9E%90%EC%9D%B8?node-id=2294-24792&t=st8bJ1H7LQ9alnmh-4',
   },
 };

--- a/src/components/molecules/card/Card.stories.tsx
+++ b/src/components/molecules/card/Card.stories.tsx
@@ -23,14 +23,21 @@ export const Default: Story = {
         <Card.Checkbox checked={args.checked} />
         <Card.TaskTitle>촬영 업체 선택 </Card.TaskTitle>
         <Card.CostSpan>400,000 원</Card.CostSpan>
-        <Chip rounded="sm" size="sm">
+        <Chip rounded='sm' size='sm'>
           2024.11.19
         </Chip>
-        <Chip type="blue" rounded="sm" size="sm">
+        <Chip type='blue' rounded='sm' size='sm'>
           예랑
         </Chip>
       </Card>
     );
+  },
+};
+
+Default.parameters = {
+  design: {
+    type: 'figma',
+    url: 'https://www.figma.com/design/cr2DuY0vceiMI5LlqWdKR2/Wedvice_%EB%94%94%EC%9E%90%EC%9D%B8?node-id=1899-49502&t=st8bJ1H7LQ9alnmh-4',
   },
 };
 
@@ -41,14 +48,21 @@ export const NoPriceCard: Story = {
       <Card checked={args.checked}>
         <Card.Checkbox checked={args.checked} />
         <Card.TaskTitle>촬영 업체 선택</Card.TaskTitle>
-        <Chip rounded="sm" size="sm">
+        <Chip rounded='sm' size='sm'>
           2024.11.19
         </Chip>
-        <Chip type="blue" rounded="sm" size="sm">
+        <Chip type='blue' rounded='sm' size='sm'>
           예랑
         </Chip>
       </Card>
     );
+  },
+};
+
+NoPriceCard.parameters = {
+  design: {
+    type: 'figma',
+    url: 'https://www.figma.com/design/cr2DuY0vceiMI5LlqWdKR2/Wedvice_%EB%94%94%EC%9E%90%EC%9D%B8?node-id=1899-49504&t=st8bJ1H7LQ9alnmh-4',
   },
 };
 
@@ -59,14 +73,21 @@ export const NoCheckboxCard: Story = {
       <Card checked={args.checked}>
         <Card.TaskTitle>촬영 업체 선택</Card.TaskTitle>
         <Card.CostSpan>400,000 원</Card.CostSpan>
-        <Chip rounded="sm" size="sm">
+        <Chip rounded='sm' size='sm'>
           2024.11.19
         </Chip>
-        <Chip type="blue" rounded="sm" size="sm">
+        <Chip type='blue' rounded='sm' size='sm'>
           예랑
         </Chip>
       </Card>
     );
+  },
+};
+
+NoCheckboxCard.parameters = {
+  design: {
+    type: 'figma',
+    url: 'https://www.figma.com/design/cr2DuY0vceiMI5LlqWdKR2/Wedvice_%EB%94%94%EC%9E%90%EC%9D%B8?node-id=1899-49526&t=st8bJ1H7LQ9alnmh-4',
   },
 };
 
@@ -78,10 +99,17 @@ export const NoCheckboxAndNoCost: Story = {
         <Card.TaskTitle>
           촬영 업체 선택촬영 업체 선택촬영 업체 선택촬영 업체 선택촬영 업체 선택
         </Card.TaskTitle>
-        <Chip type="blue" rounded="sm" size="sm">
+        <Chip type='blue' rounded='sm' size='sm'>
           예랑
         </Chip>
       </Card>
     );
+  },
+};
+
+NoCheckboxAndNoCost.parameters = {
+  design: {
+    type: 'figma',
+    url: 'https://www.figma.com/design/cr2DuY0vceiMI5LlqWdKR2/Wedvice_%EB%94%94%EC%9E%90%EC%9D%B8?node-id=1899-49633&t=st8bJ1H7LQ9alnmh-4',
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2053,6 +2053,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@figspec/components@npm:^1.0.1":
+  version: 1.0.3
+  resolution: "@figspec/components@npm:1.0.3"
+  dependencies:
+    lit: "npm:^2.1.3"
+  checksum: 10c0/78f5ee600ea1d15af7848b9fc601063acd537f49deb08aa16b95d3452c3a5783352e142c970f9a7375817099f2f54c3f9b42911f21c44ce6dab72eab20e6e20a
+  languageName: node
+  linkType: hard
+
+"@figspec/react@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "@figspec/react@npm:1.0.3"
+  dependencies:
+    "@figspec/components": "npm:^1.0.1"
+    "@lit-labs/react": "npm:^1.0.2"
+  peerDependencies:
+    react: ^16.14.0 || ^17.0.0 || ^18.0.0
+  checksum: 10c0/d5bbb79e106f522f5b867d0f55de01391edd1011e3f5d5a966ac07a5fca75f499d1d4d40a6186cf0afdc4fc4b49d808eb5d4fcbaf1784401a1ace2865dbc19be
+  languageName: node
+  linkType: hard
+
 "@humanfs/core@npm:^0.19.1":
   version: 0.19.1
   resolution: "@humanfs/core@npm:0.19.1"
@@ -2336,6 +2357,29 @@ __metadata:
   version: 3.4.0
   resolution: "@juggle/resize-observer@npm:3.4.0"
   checksum: 10c0/12930242357298c6f2ad5d4ec7cf631dfb344ca7c8c830ab7f64e6ac11eb1aae486901d8d880fd08fb1b257800c160a0da3aee1e7ed9adac0ccbb9b7c5d93347
+  languageName: node
+  linkType: hard
+
+"@lit-labs/react@npm:^1.0.2":
+  version: 1.2.1
+  resolution: "@lit-labs/react@npm:1.2.1"
+  checksum: 10c0/c92364101348400a06c3eb45a6384ca7d47c32765fdcad892827b360d0bad6cef7916f9a17744f2f471a5da3d7d73750767b885fc1521cd5e5e724badb71f014
+  languageName: node
+  linkType: hard
+
+"@lit-labs/ssr-dom-shim@npm:^1.0.0, @lit-labs/ssr-dom-shim@npm:^1.1.0":
+  version: 1.3.0
+  resolution: "@lit-labs/ssr-dom-shim@npm:1.3.0"
+  checksum: 10c0/743a9b295ef2f186712f08883da553c9990be291409615309c99aa4946cfe440a184e4213c790c24505c80beb86b9cfecf10b5fb30ce17c83698f8424f48678d
+  languageName: node
+  linkType: hard
+
+"@lit/reactive-element@npm:^1.3.0, @lit/reactive-element@npm:^1.6.0":
+  version: 1.6.3
+  resolution: "@lit/reactive-element@npm:1.6.3"
+  dependencies:
+    "@lit-labs/ssr-dom-shim": "npm:^1.0.0"
+  checksum: 10c0/10f1d25e24e32feb21c4c6f9e11d062901241602e12c4ecf746b3138f87fed4d8394194645514d5c1bfd5f33f3fd56ee8ef41344e2cb4413c40fe4961ec9d419
   languageName: node
   linkType: hard
 
@@ -2737,6 +2781,32 @@ __metadata:
   peerDependencies:
     storybook: ^8.5.2
   checksum: 10c0/8e5ae4ddd8601191010d0ffc19e5309bbd5d28445c91a1087ad40f40358a2c47a3ec91c3049ba7f1b86092a53691eaad0804cd854cafec06d8737fad54cd5cd1
+  languageName: node
+  linkType: hard
+
+"@storybook/addon-designs@npm:^8.2.0":
+  version: 8.2.0
+  resolution: "@storybook/addon-designs@npm:8.2.0"
+  dependencies:
+    "@figspec/react": "npm:^1.0.0"
+  peerDependencies:
+    "@storybook/blocks": ^8.0.0 || ^8.1.0-0 || ^8.2.0-0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+    "@storybook/components": ^8.0.0 || ^8.1.0-0 || ^8.2.0-0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+    "@storybook/theming": ^8.0.0 || ^8.1.0-0 || ^8.2.0-0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@storybook/blocks":
+      optional: true
+    "@storybook/components":
+      optional: true
+    "@storybook/theming":
+      optional: true
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 10c0/6a6ff46696daaea42a870cf18cb028f94d57048b88f8089addcfef7aca503146970ffdaaad1647e02b8cb6e4f9c030f06a4c373c634fac66291c9eaa25a5b507
   languageName: node
   linkType: hard
 
@@ -9161,6 +9231,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lit-element@npm:^3.3.0":
+  version: 3.3.3
+  resolution: "lit-element@npm:3.3.3"
+  dependencies:
+    "@lit-labs/ssr-dom-shim": "npm:^1.1.0"
+    "@lit/reactive-element": "npm:^1.3.0"
+    lit-html: "npm:^2.8.0"
+  checksum: 10c0/f44c12fa3423a4e9ca5b84651410687e14646bb270ac258325e6905affac64a575f041f8440377e7ebaefa3910b6f0d6b8b1e902cb1aa5d0849b3fdfbf4fb3b6
+  languageName: node
+  linkType: hard
+
+"lit-html@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "lit-html@npm:2.8.0"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.2"
+  checksum: 10c0/90057dee050803823ac884c1355b0213ab8c05fbe2ec63943c694b61aade5d36272068f3925f45a312835e504f9c9784738ef797009f0a756a750351eafb52d5
+  languageName: node
+  linkType: hard
+
+"lit@npm:^2.1.3":
+  version: 2.8.0
+  resolution: "lit@npm:2.8.0"
+  dependencies:
+    "@lit/reactive-element": "npm:^1.6.0"
+    lit-element: "npm:^3.3.0"
+    lit-html: "npm:^2.8.0"
+  checksum: 10c0/bf33c26b1937ee204aed1adbfa4b3d43a284e85aad8ea9763c7865365917426eded4e5888158b4136095ea42054812561fe272862b61775f1198fad3588b071f
+  languageName: node
+  linkType: hard
+
 "loader-runner@npm:^4.2.0":
   version: 4.3.0
   resolution: "loader-runner@npm:4.3.0"
@@ -13429,6 +13530,7 @@ __metadata:
     "@chromatic-com/storybook": "npm:^3.2.2"
     "@commitlint/cli": "npm:^19.7.1"
     "@commitlint/config-conventional": "npm:^19.7.1"
+    "@storybook/addon-designs": "npm:^8.2.0"
     "@storybook/addon-essentials": "npm:^8.5.2"
     "@storybook/addon-interactions": "npm:^8.5.2"
     "@storybook/addon-onboarding": "npm:^8.5.2"


### PR DESCRIPTION
## Motivation 🤔
피그마에 있는 디자인과 Storybook을 번갈아 보면서 작업을 해야 하는 번거로움이 있다고 생각했습니다.
그리고 PR을 올릴 때, 피그마 디자인을 캡처해서 올려야 하는 번거로움이 존재한다고 생각했습니다.
이러한 점을 개선하기 위해 addon/design 기능을 추가하였습니다.

## Key Changes 🔑
이런 식으로 stories 파일에 있는 Story에 parameters를 설정해주시면 됩니다!

```
NoCheckboxAndNoCost.parameters = {
  design: {
    type: 'figma',
    url: 'https://www.figma.com/design/cr2DuY0vceiMI5LlqWdKR2/Wedvice_%EB%94%94%EC%9E%90%EC%9D%B8?node-id=1899-49633&t=st8bJ1H7LQ9alnmh-4',
  }
}
```

## Attachment 📷
추가적으로 세팅과 관련한 자료는 아래에 정리해두었습니다!
https://humor12.tistory.com/39

조금 부담스럽게 크지만... 아래와 같이 나온다면 성공입니다.
![image](https://github.com/user-attachments/assets/008ec9b5-c1e1-4f1e-8be5-74981cbef318)
