### PR TITLE
[feat] BottomNavigation 구현

### DIFF
--- a/src/app/my/[username]/page.tsx
+++ b/src/app/my/[username]/page.tsx
@@ -1,0 +1,7 @@
+import { My } from '@/features/My';
+
+const MyPage = () => {
+  return <My />;
+};
+
+export default MyPage;

--- a/src/components/molecules/bottomNavigation/BottomNavigation.tsx
+++ b/src/components/molecules/bottomNavigation/BottomNavigation.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import AlarmActiveIcon from '@/assets/wed_icon/icon_28/alarm_active.svg';
+import AlarmDefaultIcon from '@/assets/wed_icon/icon_28/alarm_default.svg';
+import { usePathname, useRouter } from 'next/navigation';
+import React, { useCallback } from 'react';
+
+type NavItem = {
+  label: string;
+  defaultIcon: React.ReactNode;
+  activeIcon: React.ReactNode;
+  href: string;
+};
+
+const NAV_ITEMS: NavItem[] = [
+  {
+    label: '홈',
+    defaultIcon: <AlarmDefaultIcon />,
+    activeIcon: <AlarmActiveIcon />,
+    href: '/home',
+  },
+  {
+    label: '테스크',
+    defaultIcon: <AlarmDefaultIcon />,
+    activeIcon: <AlarmActiveIcon />,
+    href: '/task',
+  },
+  {
+    label: '달력',
+    defaultIcon: <AlarmDefaultIcon />,
+    activeIcon: <AlarmActiveIcon />,
+    href: '/calendar',
+  },
+  {
+    label: '마이',
+    defaultIcon: <AlarmDefaultIcon />,
+    activeIcon: <AlarmActiveIcon />,
+    href: '/my',
+  },
+];
+
+export const BottomNavigation = () => {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const isActive = useCallback(
+    (href: string) => pathname.startsWith(href),
+    [pathname],
+  );
+
+  return (
+    <nav className='mt-auto rounded-t-[20px] border-t border-gray-300 bg-black/40 px-6 py-3'>
+      <ul className='flex justify-between'>
+        {NAV_ITEMS.map((item) => {
+          const active = isActive(item.href);
+          return (
+            <li
+              key={item.label}
+              onClick={() => router.push(item.href)}
+              className='flex flex-1 cursor-pointer flex-col items-center gap-1'
+            >
+              {active ? item.activeIcon : item.defaultIcon}
+              <span
+                className={`text-xs text-white ${active ? 'opacity-100' : 'opacity-30'}`}
+              >
+                {item.label}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+};
+
+export default BottomNavigation;

--- a/src/components/molecules/bottomNavigation/index.ts
+++ b/src/components/molecules/bottomNavigation/index.ts
@@ -1,0 +1,1 @@
+export { BottomNavigation } from '@/components/molecules/bottomNavigation/BottomNavigation';

--- a/src/features/My/My.tsx
+++ b/src/features/My/My.tsx
@@ -1,0 +1,7 @@
+export const My = () => {
+  return (
+    <div className='relative flex h-full w-full flex-col'>
+      마이 페이지 테스트
+    </div>
+  );
+};

--- a/src/features/My/index.ts
+++ b/src/features/My/index.ts
@@ -1,0 +1,1 @@
+export { My } from './My';

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -1,3 +1,4 @@
+import { BottomNavigation } from '@/components/molecules/bottomNavigation';
 import MemoLink from '@/components/molecules/memo/MemoLink';
 import { Navigation } from '@/components/molecules/navigation';
 
@@ -6,6 +7,7 @@ export const Home = () => {
     <div className='relative flex h-full w-full flex-col'>
       <Navigation />
       <MemoLink />
+      <BottomNavigation />
     </div>
   );
 };


### PR DESCRIPTION
## Motivation 🤔
- 하단 내비게이션 구현
## Key Changes 🔑
- active 상태에 따른 아이콘, 텍스트 변경
  - 아이콘 이미지 미발행으로 임시 svg로 대체
- 페이지 이동을 위한 router 연결
- 임시 My 페이지 구현
  - 테스크 : `/task`
  - 캘린더 : `/calendar`
  - 위 루트로 페이지 구현하면 이동 됩니당
## Attachment 📷
<img width="480" alt="스크린샷 2025-06-13 오후 8 47 23" src="https://github.com/user-attachments/assets/5fae9bb3-d403-4daf-9156-923545628a13" />
