### PR TITLE
[feat] 캘린더 페이지 내 Todo 컴포넌트 구현

### DIFF
--- a/src/app/calendar/add/page.tsx
+++ b/src/app/calendar/add/page.tsx
@@ -1,4 +1,4 @@
-import { AddCalendar } from '@/features/calendar/add';
+import { AddCalendar } from '@/features/calendar';
 
 const AddCalendarPage = () => {
   return <AddCalendar />;

--- a/src/app/calendar/layout.tsx
+++ b/src/app/calendar/layout.tsx
@@ -1,0 +1,7 @@
+import { PropsWithChildren } from 'react';
+
+const CalendarLayout = ({ children }: PropsWithChildren) => {
+  return <main className='h-full w-full'>{children}</main>;
+};
+
+export default CalendarLayout;

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,0 +1,7 @@
+import { Calendar } from '@/features/calendar';
+
+const CalendarPage = () => {
+  return <Calendar />;
+};
+
+export default CalendarPage;

--- a/src/features/calendar/Calendar.tsx
+++ b/src/features/calendar/Calendar.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import AlarmDefaultIcon from '@/assets/wed_icon/icon_28/alarm_default.svg';
+import { BottomNavigation } from '@/components/molecules/bottomNavigation';
+import { LeftAlignedTopBar } from '@/components/molecules/topBar';
+import { useRouter } from 'next/navigation';
+
+export const Calendar = () => {
+  const router = useRouter();
+
+  return (
+    <div className='relative flex h-full w-full flex-col bg-black'>
+      <LeftAlignedTopBar
+        title='2024년 12월'
+        button={<AlarmDefaultIcon />}
+        onButtonClick={() => router.push('/notification')}
+      />
+
+      <div className='px-5 pt-4'></div>
+
+      <BottomNavigation />
+    </div>
+  );
+};
+
+export default Calendar;

--- a/src/features/calendar/add/index.ts
+++ b/src/features/calendar/add/index.ts
@@ -1,1 +1,0 @@
-export { AddCalendar } from './AddCalendar';

--- a/src/features/calendar/components/CalendarTodo.tsx
+++ b/src/features/calendar/components/CalendarTodo.tsx
@@ -1,0 +1,29 @@
+export type TodoType = '예신' | '예랑' | '함께';
+
+const colorMap: Record<TodoType, string> = {
+  예신: 'bg-primary-300',
+  예랑: 'bg-pink',
+  함께: 'bg-blue',
+};
+
+interface CalendarTodoProps {
+  title: string;
+  category: string;
+  type: TodoType;
+}
+
+export const CalendarTodo = ({ title, category, type }: CalendarTodoProps) => {
+  const barColor = colorMap[type];
+  return (
+    <div className='relative flex h-[77px] w-full items-center gap-3 rounded-lg bg-gray-100 p-4'>
+      <span
+        className={`absolute left-0 h-[45px] w-1 rounded-[4.5px] ${barColor}`}
+        aria-hidden='true'
+      />
+      <div className='flex h-full flex-1 flex-col justify-between font-medium'>
+        <h4 className='text-base text-gray-900'>{title}</h4>
+        <p className='text-xs text-gray-700'>{category}</p>
+      </div>
+    </div>
+  );
+};

--- a/src/features/calendar/index.ts
+++ b/src/features/calendar/index.ts
@@ -1,0 +1,2 @@
+export { AddCalendar } from './add/AddCalendar';
+export { Calendar } from './Calendar';


### PR DESCRIPTION
## Motivation 🤔
- 캘린더 페이지 내 일정 표시용 UI 컴포넌트 구현

## Key Changes 🔑
- 캘린더 페이지 제작
  - `TopBar`, `BottomNavigation` 컴포넌트 추가
  - 캘린더 페이지 및 캘린더 일정 추가 페이지 import 경로 추가
- `CalendarTodo` 컴포넌트 제작
  - Type(예신, 예랑, 함께)별 `barColor` 출력
- TODO
  - 캘린더 구현
  - 특정 날짜 클릭 시 출력되는 Bottom Sheet 구현
## Attachment 📷
<img width="460" alt="image" src="https://github.com/user-attachments/assets/1f751e9b-f3e5-4a87-a122-e671b4780146" />
