### PR TITLE
[feat] HomeList Component 구현

### DIFF
--- a/src/components/molecules/homeList/HomeListItem.tsx
+++ b/src/components/molecules/homeList/HomeListItem.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+type Size = 'small' | 'medium';
+
+const sizeConfig = {
+  small: {
+    wrapper: 'w-[334px] h-[63px]',
+    padding: 'py-2 px-3',
+    titleSize: 'text-base',
+    round: 'rounded-md',
+  },
+  medium: {
+    wrapper: 'w-[350px] h-[89px]',
+    padding: 'p-5',
+    titleSize: 'text-lg',
+    round: 'rounded-lg',
+  },
+} as const;
+
+interface HomeListProps {
+  size?: Size;
+  title: string;
+  date?: string;
+}
+
+export const HomeListItem = ({
+  size = 'medium',
+  title,
+  date,
+}: HomeListProps): JSX.Element => {
+  const { wrapper, padding, round, titleSize } = sizeConfig[size];
+
+  return (
+    <div
+      className={`${wrapper} ${padding} ${round} bg-gray-100 font-medium active:bg-gray-200`}
+    >
+      <div className={`${titleSize} text-white`}>{title}</div>
+      {date && (
+        <div className='mt-2 text-sm leading-[18px] text-gray-600'>{date}</div>
+      )}
+    </div>
+  );
+};

--- a/src/components/molecules/homeList/homeListCard.tsx
+++ b/src/components/molecules/homeList/homeListCard.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import RightArrow from '@/assets/wed_icon/icon_16/rightarrow_default_gray 800.svg';
+import { HomeListItem } from './HomeListItem';
+
+type HomeListType = 'done' | 'todo';
+
+const titleMap: Record<HomeListType, string> = {
+  done: '완료한 리스트',
+  todo: '남은 리스트',
+};
+
+interface HomeListItem {
+  title: string;
+  date: string;
+}
+
+interface HomeListCardProps {
+  type: HomeListType;
+  items: HomeListItem[];
+  onClick?: () => void;
+}
+
+export const HomeListCard = ({
+  type,
+  items,
+  onClick,
+}: HomeListCardProps): JSX.Element => {
+  const slicedItems = items.slice(0, 3);
+  const title = titleMap[type];
+
+  return (
+    <div className='mt-4 rounded-lg bg-gray-100 p-5'>
+      <div className='mb-4 flex items-center justify-between'>
+        <span className='flex items-center gap-1 text-base font-medium text-white'>
+          {title}
+          <span className={'font-semibold text-primary-500'}>
+            {items.length}개
+          </span>
+        </span>
+
+        <button
+          onClick={onClick}
+          className='flex items-center text-sm font-medium text-gray-600'
+        >
+          전체보기
+          <RightArrow />
+        </button>
+      </div>
+
+      <div className='flex flex-col items-center space-y-2'>
+        {slicedItems.map(({ title, date }) => (
+          <HomeListItem
+            key={title + date}
+            size='small'
+            title={title}
+            date={date}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/molecules/homeList/index.ts
+++ b/src/components/molecules/homeList/index.ts
@@ -1,0 +1,2 @@
+export { HomeListCard } from './homeListCard';
+export { HomeListItem } from './HomeListItem';

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -1,17 +1,39 @@
+'use client';
+
 import { BottomNavigation } from '@/components/molecules/bottomNavigation';
+import { HomeListCard } from '@/components/molecules/homeList/homeListCard';
 import MemoLink from '@/components/molecules/memo/MemoLink';
 import { Navigation } from '@/components/molecules/navigation';
 import { ProgressCard, TabProgressCard } from '@/components/molecules/progress';
 
+// mock data
+const homeListItems = [
+  { title: '촬영업체 선택1', date: '2025.07.08' },
+  { title: '촬영업체 선택2', date: '2025.07.08' },
+  { title: '촬영업체 선택3', date: '2025.07.08' },
+  { title: '촬영업체 선택4', date: '2025.07.08' },
+  { title: '촬영업체 선택5', date: '2025.07.08' },
+];
+
 export const Home = () => {
   return (
     <div className='relative flex h-full w-full flex-col'>
-      <div className='mx-5 flex flex-col'>
+      <div className='mx-5 flex flex-1 flex-col overflow-y-auto'>
         <Navigation />
         <MemoLink />
         {/* TODO : percentage 받아오기 */}
         <ProgressCard percentage={54} />
         <TabProgressCard />
+        <HomeListCard
+          type='todo'
+          items={homeListItems}
+          onClick={() => console.log('남은 리스트 click')}
+        />
+        <HomeListCard
+          type='done'
+          items={homeListItems}
+          onClick={() => console.log('완료한 리스트 click')}
+        />
       </div>
       <BottomNavigation />
     </div>


### PR DESCRIPTION
## Motivation 🤔
- Home Default 화면의 남은 리스트, 완료한 리스트 영역 구현

## Key Changes 🔑
- HomeListItem : title, date로 이루어진 리스트 컴포넌트
- HomeListCard : 개수 및 전체보기 버튼을 포함한 HomeListItem의 Container
- TODO : data 받아오기, 페이지 이동

## Attachment 📷
![스크린샷 2025-07-09 오후 10 26 20](https://github.com/user-attachments/assets/613426f8-c836-4f95-a08a-5960d25301eb)
