### PR TITLE
[feat] Calendar 페이지 캘린더 구현

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,7 +1,14 @@
+'use client';
+
+import { CalendarProvider } from '@/contexts/calendar';
 import { Calendar } from '@/features/calendar';
 
 const CalendarPage = () => {
-  return <Calendar />;
+  return (
+    <CalendarProvider>
+      <Calendar />
+    </CalendarProvider>
+  );
 };
 
 export default CalendarPage;

--- a/src/contexts/calendar/CalendarContext.ts
+++ b/src/contexts/calendar/CalendarContext.ts
@@ -1,0 +1,25 @@
+import { createContext, useContext } from 'react';
+
+interface CalendarContextProps {
+  selectedDate: Date;
+  setSelectedDate: (date: Date) => void;
+  isSlideOpen: boolean;
+  setIsSlideOpen: (value: boolean) => void;
+}
+
+export const CalendarContext = createContext<CalendarContextProps | undefined>(
+  undefined,
+);
+
+// CalendarContext 사용을 위한 Hook
+export const useCalendarContext = () => {
+  const context = useContext(CalendarContext);
+  if (!context) {
+    throw new Error(
+      'CalendarContext 사용할 수 없습니다. CalendarProvider를 감싸주세요.',
+    );
+  }
+  return context;
+};
+
+export default useCalendarContext;

--- a/src/contexts/calendar/CalendarProvider.tsx
+++ b/src/contexts/calendar/CalendarProvider.tsx
@@ -1,0 +1,20 @@
+import { ReactNode, useState } from 'react';
+import { CalendarContext } from './CalendarContext';
+
+export const CalendarProvider = ({ children }: { children: ReactNode }) => {
+  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+  const [isSlideOpen, setIsSlideOpen] = useState<boolean>(false);
+
+  return (
+    <CalendarContext.Provider
+      value={{
+        selectedDate,
+        setSelectedDate,
+        isSlideOpen,
+        setIsSlideOpen,
+      }}
+    >
+      {children}
+    </CalendarContext.Provider>
+  );
+};

--- a/src/contexts/calendar/index.ts
+++ b/src/contexts/calendar/index.ts
@@ -1,0 +1,2 @@
+export { useCalendarContext } from './CalendarContext';
+export { CalendarProvider } from './CalendarProvider';

--- a/src/features/calendar/Calendar.tsx
+++ b/src/features/calendar/Calendar.tsx
@@ -3,20 +3,134 @@
 import AlarmDefaultIcon from '@/assets/wed_icon/icon_28/alarm_default.svg';
 import { BottomNavigation } from '@/components/molecules/bottomNavigation';
 import { LeftAlignedTopBar } from '@/components/molecules/topBar';
+import { useCalendarContext } from '@/contexts/calendar';
+import { CalendarData } from '@/types/calendar/calendarTypes';
 import { useRouter } from 'next/navigation';
+import { CalendarView } from './components/CalendarView';
+
+const dayData: CalendarData[] = [
+  {
+    id: '1',
+    title: '스탭 컨설',
+    category: '드레스/정장',
+    date: '2025-07-01',
+    manager: '예랑',
+  },
+  {
+    id: '14',
+    title: '결혼 반지',
+    category: '드레스/정장',
+    date: '2025-07-01',
+    manager: '예신',
+  },
+  {
+    id: '15',
+    title: '휴즈 하늘',
+    category: '장소/예식장',
+    date: '2025-07-01',
+    manager: '함께',
+  },
+  {
+    id: '2',
+    title: '스탭 컨설',
+    category: '장소/예식장',
+    date: '2025-07-02',
+    manager: '함께',
+  },
+  {
+    id: '3',
+    title: '학업 후기',
+    category: '드레스/정장',
+    date: '2025-07-05',
+    manager: '예신',
+  },
+  {
+    id: '4',
+    title: '스탭 컨설',
+    category: '드레스/정장',
+    date: '2025-07-05',
+    manager: '예랑',
+  },
+  {
+    id: '5',
+    title: '혜이 브랜드 가보기',
+    category: '드레스/정장',
+    date: '2025-07-06',
+    manager: '예랑',
+  },
+  {
+    id: '6',
+    title: '스탭 컨설',
+    category: '드레스/정장',
+    date: '2025-07-06',
+    manager: '함께',
+  },
+  {
+    id: '7',
+    title: '스탭 컨설',
+    category: '드레스/정장',
+    date: '2025-07-06',
+    manager: '예신',
+  },
+  {
+    id: '8',
+    title: '드레스샵',
+    category: '장소/예식장',
+    date: '2025-07-09',
+    manager: '예랑',
+  },
+  {
+    id: '9',
+    title: '분식 부제',
+    category: '장소/예식장',
+    date: '2025-07-12',
+    manager: '함께',
+  },
+  {
+    id: '10',
+    title: '드레스 강',
+    category: '드레스/정장',
+    date: '2025-07-21',
+    manager: '예신',
+  },
+  {
+    id: '11',
+    title: '정장 영재',
+    category: '장소/예식장',
+    date: '2025-07-21',
+    manager: '예랑',
+  },
+  {
+    id: '12',
+    title: '정장 가능',
+    category: '장소/예식장',
+    date: '2025-07-31',
+    manager: '함께',
+  },
+  {
+    id: '13',
+    title: '결혼 반지',
+    category: '드레스/정장',
+    date: '2025-07-31',
+    manager: '예신',
+  },
+];
 
 export const Calendar = () => {
   const router = useRouter();
+  const { selectedDate } = useCalendarContext();
 
   return (
-    <div className='relative flex h-full w-full flex-col bg-black'>
+    <div className='relative flex h-full w-full flex-col'>
       <LeftAlignedTopBar
-        title='2024년 12월'
+        title={`${selectedDate.getFullYear()}년 ${selectedDate.getMonth() + 1}월`}
         button={<AlarmDefaultIcon />}
         onButtonClick={() => router.push('/notification')}
       />
 
-      <div className='px-5 pt-4'></div>
+      <div className='h-full flex-1 overflow-y-scroll px-5 pt-4 scrollbar-hide'>
+        <CalendarView data={dayData} />
+      </div>
 
       <BottomNavigation />
     </div>

--- a/src/features/calendar/components/CalendarView.tsx
+++ b/src/features/calendar/components/CalendarView.tsx
@@ -1,0 +1,61 @@
+import { useCalendarContext } from '@/contexts/calendar';
+import {
+  CalendarData,
+  colorMap,
+  getEventsForDate,
+  SelectedDate,
+} from '@/types/calendar/calendarTypes';
+import { format } from 'date-fns';
+import Calendar from 'react-calendar';
+
+import './styles.css';
+
+const NAV_HEIGHT = 88;
+
+export const CalendarView = ({
+  data,
+}: {
+  data: CalendarData[];
+}): JSX.Element => {
+  const { selectedDate, setSelectedDate, setIsSlideOpen } =
+    useCalendarContext();
+
+  const handleSelect = (newDate: SelectedDate) => {
+    if (!(newDate instanceof Date)) return;
+
+    setSelectedDate(newDate);
+    setIsSlideOpen(true);
+  };
+
+  const tileContent = ({ date }: { date: Date }) => {
+    const dayEvents = getEventsForDate(data, date);
+    return (
+      <div className='mt-2 flex w-full flex-col gap-1 px-0.5 text-xs text-white'>
+        {dayEvents.map((event) => (
+          <div
+            key={event.id}
+            className={`overflow-hidden whitespace-nowrap rounded p-0.5 ${colorMap[event.manager]}`}
+          >
+            {event.title}
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <div
+      className='flex flex-col items-center'
+      style={{ height: `calc(100% - ${NAV_HEIGHT}px)` }}
+    >
+      <Calendar
+        className='react-calendar'
+        onChange={handleSelect}
+        value={selectedDate}
+        calendarType='gregory'
+        formatDay={(_, date) => format(date, 'd')}
+        tileContent={tileContent}
+      />
+    </div>
+  );
+};

--- a/src/features/calendar/components/styles.css
+++ b/src/features/calendar/components/styles.css
@@ -1,0 +1,120 @@
+.react-calendar {
+  color: #e2e2e8;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  transition: height 0.3s ease;
+  width: 100%;
+}
+
+.react-calendar__month-view,
+.react-calendar__viewContainer,
+.react-calendar__month-view__week,
+.react-calendar__month-view > div {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.react-calendar__month-view__weeks__week {
+  flex: 1;
+  display: flex;
+}
+
+.react-calendar__tile--active {
+  background: transparent;
+}
+
+.react-calendar__tile--active abbr {
+  background: #9360f9;
+  border-radius: 50%;
+}
+
+.react-calendar__tile--active:hover abbr {
+  background: #9360f9;
+}
+
+.react-calendar__tile:hover abbr {
+  background: #9360f9;
+  border-radius: 50%;
+}
+
+.react-calendar__month-view__weekdays__weekday abbr {
+  text-decoration: none;
+}
+
+.react-calendar__month-view__weekdays__weekday {
+  color: #a9aabc;
+  margin-bottom: 20px;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.react-calendar__navigation {
+  display: none;
+}
+
+.react-calendar__month-view__days {
+  flex: 1 !important;
+  display: flex !important;
+  flex-direction: row !important;
+  height: 100% !important;
+}
+
+.react-calendar__tile {
+  font-size: 14px;
+  height: auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border: none;
+  color: #e2e2e8;
+  position: relative;
+  padding: 4px;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.react-calendar__tile abbr {
+  position: relative;
+  z-index: 2;
+  text-decoration: none;
+
+  width: 20px;
+  height: 20px;
+
+  text-decoration: none;
+}
+
+.react-calendar__tile--now {
+  background: transparent;
+}
+
+.react-calendar__tile--now abbr {
+  background: #ffffff;
+  border-radius: 50%;
+  color: #17181c;
+}
+
+.react-calendar__tile--now:hover abbr {
+  background: #ffffff;
+}
+
+.react-calendar__month-view__days__day--neighboringMonth abbr {
+  opacity: 40%;
+}
+
+.react-calendar button {
+  margin: 0;
+  border: 0;
+  outline: none;
+  background: transparent;
+  text-align: center;
+
+  min-height: 96px;
+}
+
+.react-calendar button:enabled:hover,
+.react-calendar button:enabled:focus {
+  background: transparent;
+}

--- a/src/types/calendar/calendarTypes.ts
+++ b/src/types/calendar/calendarTypes.ts
@@ -1,0 +1,22 @@
+import { format } from 'date-fns';
+
+export type TodoType = '예신' | '예랑' | '함께';
+
+export interface CalendarData {
+  id: string;
+  title: string;
+  category: string;
+  date: string;
+  manager: TodoType;
+}
+
+type DatePiece = Date | null;
+export type SelectedDate = DatePiece | [DatePiece, DatePiece];
+
+export const getEventsForDate = (
+  data: CalendarData[],
+  date: Date,
+): CalendarData[] => {
+  const dateStr = format(date, 'yyyy-MM-dd');
+  return data.filter((list) => list.date === dateStr);
+};


### PR DESCRIPTION
## Motivation 🤔
- Calendar 페이지 내 `CalendarView` 컴포넌트 구현

## Key Changes 🔑

### `CalendarContext` 및 `CalendarProvider` 구현 
  - 전역 상태 관리를 위한 `useCalendarContex` 훅 구현 
  - `selectedDate`(선택한 날짜), `isSlideOpen`(Bottom Sheet 열림 여부) 상태를 전역으로 공유

### `CalendarView` 컴포넌트 구현
  - Calendar 일정 관련 더미 데이터 추가 
  - `TopBar`에서 선택한 날짜(없을 경우 오늘 날짜)를 기준으로 출력되도록 수정 
  - 일정이 있을 경우 `tileContent`를 통해 일정 보여지도록 로직 구현 
  - Calendar 스타일 커스터마이징(style.css)

### `calendarTypes` 관련 타입 및 상수를 type.ts로 분리하여 관리

## Attachment 📷
<img width="223" height="654" alt="image" src="https://github.com/user-attachments/assets/a9747975-d984-43a0-add9-819fb59c975d" />
