### PR TITLE
[feat] Calendar 페이지 Bottom Sheet 구현

### DIFF
--- a/src/components/atoms/bottomSheet/style.css
+++ b/src/components/atoms/bottomSheet/style.css
@@ -17,3 +17,12 @@
 [data-rsbs-overlay] {
   z-index: 99;
 }
+
+.calendar {
+  --rsbs-bg: #17181c !important;
+  --rsbs-overlay-rounded: 0px !important;
+}
+
+.calendar [data-rsbs-overlay] {
+  border-top: 1px solid #2c2e3a;
+}

--- a/src/components/molecules/bottomNavigation/BottomNavigation.tsx
+++ b/src/components/molecules/bottomNavigation/BottomNavigation.tsx
@@ -49,7 +49,7 @@ export const BottomNavigation = () => {
   );
 
   return (
-    <nav className='mt-auto rounded-t-[20px] border-t border-gray-300 bg-black/40 px-6 py-3'>
+    <nav className='z-10 mt-auto rounded-t-[20px] border-t border-gray-300 bg-black/40 px-6 py-3'>
       <ul className='flex justify-between'>
         {NAV_ITEMS.map((item) => {
           const active = isActive(item.href);

--- a/src/features/calendar/Calendar.tsx
+++ b/src/features/calendar/Calendar.tsx
@@ -4,8 +4,9 @@ import AlarmDefaultIcon from '@/assets/wed_icon/icon_28/alarm_default.svg';
 import { BottomNavigation } from '@/components/molecules/bottomNavigation';
 import { LeftAlignedTopBar } from '@/components/molecules/topBar';
 import { useCalendarContext } from '@/contexts/calendar';
-import { CalendarData } from '@/types/calendar/calendarTypes';
+import { CalendarData, getEventsForDate } from '@/types/calendar/calendarTypes';
 import { useRouter } from 'next/navigation';
+import { CalendarBottomSheet } from './components/CalendarBottomSheet';
 import { CalendarView } from './components/CalendarView';
 
 const dayData: CalendarData[] = [
@@ -119,6 +120,7 @@ const dayData: CalendarData[] = [
 export const Calendar = () => {
   const router = useRouter();
   const { selectedDate } = useCalendarContext();
+  const currentEvents = getEventsForDate(dayData, selectedDate);
 
   return (
     <div className='relative flex h-full w-full flex-col'>
@@ -130,6 +132,7 @@ export const Calendar = () => {
 
       <div className='h-full flex-1 overflow-y-scroll px-5 pt-4 scrollbar-hide'>
         <CalendarView data={dayData} />
+        <CalendarBottomSheet data={currentEvents} />
       </div>
 
       <BottomNavigation />

--- a/src/features/calendar/components/CalendarBottomSheet.tsx
+++ b/src/features/calendar/components/CalendarBottomSheet.tsx
@@ -1,0 +1,82 @@
+import { BottomSheet } from '@/components/atoms/bottomSheet';
+import { useCalendarContext } from '@/contexts/calendar';
+import { CalendarData, WEEKDAY } from '@/types/calendar/calendarTypes';
+import { useRouter } from 'next/navigation';
+import { CSSProperties } from 'react';
+import { CalendarTodo } from './CalendarTodo';
+
+const BOTTOM_SHEET_MIN_HEIGHT = 403;
+const BOTTOM_SHEET_MAX_HEIGHT = 627;
+
+export const CalendarBottomSheet = ({ data }: { data: CalendarData[] }) => {
+  const { selectedDate, isSlideOpen, setIsSlideOpen } = useCalendarContext();
+
+  const handleOnDismiss = () => {
+    setIsSlideOpen(false);
+  };
+
+  return (
+    <BottomSheet
+      open={isSlideOpen}
+      onDismiss={handleOnDismiss}
+      snapPoints={({}) => [BOTTOM_SHEET_MIN_HEIGHT, BOTTOM_SHEET_MAX_HEIGHT]}
+      defaultSnap={() => BOTTOM_SHEET_MIN_HEIGHT}
+      blocking={false}
+      header={<BottomSheetHeader selectedDate={selectedDate} />}
+      className='pb-24'
+      style={
+        {
+          '--rsbs-bg': '#17181C',
+          '--rsbs-overlay-rounded': '0px',
+        } as CSSProperties
+      }
+    >
+      <BottomSheetContent data={data} />
+    </BottomSheet>
+  );
+};
+
+const BottomSheetHeader = ({ selectedDate }: { selectedDate: Date }) => {
+  const router = useRouter();
+
+  return (
+    <div className='flex items-center justify-between p-1 font-medium'>
+      <div className='flex items-center gap-1'>
+        <span className='text-lg text-white'>{selectedDate.getDate()}일</span>
+        <span className='text-base text-gray-700'>
+          {WEEKDAY[selectedDate.getDay()]}요일
+        </span>
+      </div>
+
+      <button
+        className='text-sm text-primary-500'
+        onClick={() => router.push('/calendar/add')}
+      >
+        리스트추가
+      </button>
+    </div>
+  );
+};
+
+const BottomSheetContent = ({ data }: { data: CalendarData[] }) => {
+  if (data.length === 0) {
+    return (
+      <div className='flex h-full min-h-[300px] items-center justify-center px-4 text-center text-base font-medium text-gray-500'>
+        <span>표시된 알림이 없어요</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className='grid gap-2 px-4 pb-4'>
+      {data.map((todo) => (
+        <CalendarTodo
+          key={todo.id}
+          title={todo.title}
+          category={todo.category}
+          type={todo.manager}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/features/calendar/components/CalendarBottomSheet.tsx
+++ b/src/features/calendar/components/CalendarBottomSheet.tsx
@@ -2,7 +2,6 @@ import { BottomSheet } from '@/components/atoms/bottomSheet';
 import { useCalendarContext } from '@/contexts/calendar';
 import { CalendarData, WEEKDAY } from '@/types/calendar/calendarTypes';
 import { useRouter } from 'next/navigation';
-import { CSSProperties } from 'react';
 import { CalendarTodo } from './CalendarTodo';
 
 const BOTTOM_SHEET_MIN_HEIGHT = 403;
@@ -23,13 +22,7 @@ export const CalendarBottomSheet = ({ data }: { data: CalendarData[] }) => {
       defaultSnap={() => BOTTOM_SHEET_MIN_HEIGHT}
       blocking={false}
       header={<BottomSheetHeader selectedDate={selectedDate} />}
-      className='pb-24'
-      style={
-        {
-          '--rsbs-bg': '#17181C',
-          '--rsbs-overlay-rounded': '0px',
-        } as CSSProperties
-      }
+      className='calendar pb-24'
     >
       <BottomSheetContent data={data} />
     </BottomSheet>

--- a/src/features/calendar/components/CalendarTodo.tsx
+++ b/src/features/calendar/components/CalendarTodo.tsx
@@ -1,10 +1,4 @@
-export type TodoType = '예신' | '예랑' | '함께';
-
-const colorMap: Record<TodoType, string> = {
-  예신: 'bg-primary-300',
-  예랑: 'bg-pink',
-  함께: 'bg-blue',
-};
+import { TodoType, colorMap } from '@/types/calendar/calendarTypes';
 
 interface CalendarTodoProps {
   title: string;

--- a/src/types/calendar/calendarTypes.ts
+++ b/src/types/calendar/calendarTypes.ts
@@ -1,5 +1,7 @@
 import { format } from 'date-fns';
 
+export const WEEKDAY = ['일', '월', '화', '수', '목', '금', '토'];
+
 export type TodoType = '예신' | '예랑' | '함께';
 
 export interface CalendarData {
@@ -9,6 +11,12 @@ export interface CalendarData {
   date: string;
   manager: TodoType;
 }
+
+export const colorMap: Record<TodoType, string> = {
+  예신: 'bg-primary-300',
+  예랑: 'bg-pink',
+  함께: 'bg-blue',
+};
 
 type DatePiece = Date | null;
 export type SelectedDate = DatePiece | [DatePiece, DatePiece];


### PR DESCRIPTION
## Motivation 🤔
- Calendar 페이지 내 `CalendarBottomSheet` 컴포넌트 구현

## Key Changes 🔑
- `CalendarBottomSheet` 구현 
  - 선택한 날짜에 따른 Bottom Sheet 구현 
  - 일정이 없을 경우 '표시된 알림이 없어요' 문구 출력 
  - `BottomSheetHeader`에서 날짜 및 요일 표시, 리스트 추가 버튼 연결 
  - `CalendarTodo` 컴포넌트로 일정 항목 표시
- `BottomNavigation`에 `z-10` 추가
  - `CalendarBottomSheet`가 `BottomNavigation` 뒤에서 올라오도록 `z-index` 설정
- `CalendarBottomSheet`를 위한 style 추가


### TODO
- Bottom Sheet의 Height를 고려하여 CalendarView 월/주 로 보여주는 기능
- Bottom Navigation 의 배경이 투명도 40으로 설정되어 있어 콘텐츠가 비쳐 보이는 현상가 있어 의도한 디자인인지 문의함!

## Attachment 📷
<img width="200" height="600" alt="image" src="https://github.com/user-attachments/assets/45b2034c-c316-48cc-bb50-18e64bafcc39" />
<img width="200" height="600" alt="image" src="https://github.com/user-attachments/assets/edd420a7-611c-4a91-b4f5-c67fa9ca6ab0" />
